### PR TITLE
Update harmoniscope_low_priority.json to include glass and glass panes

### DIFF
--- a/src/main/resources/data/magichem/tags/blocks/harmoniscope_low_priority.json
+++ b/src/main/resources/data/magichem/tags/blocks/harmoniscope_low_priority.json
@@ -22,6 +22,8 @@
     "minecraft:ice",
     "minecraft:packed_ice",
     "minecraft:blue_ice",
-    "minecraft:sea_lantern"
+    "minecraft:sea_lantern",
+    "#forge:glass",
+    "#forge:glass_panes"
   ]
 }


### PR DESCRIPTION
Added #forge:glass and #forge:glass_panes to the tag for blocks breakable for the harmoniscope.