### PR TITLE
Fix #forge:steam tag

### DIFF
--- a/src/main/resources/data/forge/tags/fluids/steam.json
+++ b/src/main/resources/data/forge/tags/fluids/steam.json
@@ -1,7 +1,6 @@
 {
   "replace": false,
   "values": [
-    "magichem:steam",
-    "magichem:flowing_steam"
+    "magichem:steam"
   ]
 }


### PR DESCRIPTION
Changed the MagiChem steam tag addition to only have the fluid steam, not the flowing steam block which is incompatible with fluid tags, causing the entire tag to fail on load.