### PR TITLE
patches about observer

### DIFF
--- a/src/main/java/com/aranaira/magichem/block/entity/AstralObserverBlockEntity.java
+++ b/src/main/java/com/aranaira/magichem/block/entity/AstralObserverBlockEntity.java
@@ -238,7 +238,7 @@ public class AstralObserverBlockEntity extends BlockEntity implements MenuProvid
 
     @Override
     public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
-        if(cap == ForgeCapabilities.ITEM_HANDLER) {
+        if(cap == ForgeCapabilities.ITEM_HANDLER && side != null) {
             if(side == Direction.UP || side == Direction.DOWN)
                 return lazyItemHandler.cast();
             else

--- a/src/main/java/com/aranaira/magichem/gui/AstralObserverMenu.java
+++ b/src/main/java/com/aranaira/magichem/gui/AstralObserverMenu.java
@@ -75,7 +75,7 @@ public class AstralObserverMenu extends AbstractContainerMenu {
 
     @Override
     public ItemStack quickMoveStack(Player pPlayer, int pIndex) {
-        ItemStack result = InventoryHelper.quickMoveStackHandler(pIndex, slots, DIRSPEC, new Vector2i(SLOT_INVENTORY_BEGIN, SLOT_INVENTORY_COUNT), SPEC_FROM_INVENTORY, SPEC_TO_INVENTORY, SPEC_CONTAINER);
+        ItemStack result = InventoryHelper.quickMoveStackHandler(pIndex, slots, DIRSPEC, new Vector2i(SLOT_INVENTORY_BEGIN, SLOT_INVENTORY_COUNT), SPEC_FROM_INVENTORY, SPEC_TO_INVENTORY, SPEC_CONTAINER, true);
 
         slots.get(pIndex).set(result);
 

--- a/src/main/java/com/aranaira/magichem/util/InventoryHelper.java
+++ b/src/main/java/com/aranaira/magichem/util/InventoryHelper.java
@@ -49,7 +49,7 @@ public class InventoryHelper {
      * @return Ideally ItemStack.EMPTY if everything worked correctly.
      */
     public static ItemStack quickMoveStackHandler(int pTargetSlot, NonNullList<Slot> pSlots, Pair<Item, Integer>[] pDirectSpec, Vector2i pInventoryRange, Vector2i[] pInventoryOutgoingSpec, Vector2i[] pInventoryIncomingSpec, Pair<Integer, Vector2i> pContainerSpec) {
-        ItemStack modStack = pSlots.get(pTargetSlot).getItem();
+        ItemStack modStack = pSlots.get(pTargetSlot).remove(114514);
         boolean doContainerLimiting = pContainerSpec != null;
 
         //First we check to see if the slot was within the provided inventory range.

--- a/src/main/java/com/aranaira/magichem/util/InventoryHelper.java
+++ b/src/main/java/com/aranaira/magichem/util/InventoryHelper.java
@@ -49,7 +49,12 @@ public class InventoryHelper {
      * @return Ideally ItemStack.EMPTY if everything worked correctly.
      */
     public static ItemStack quickMoveStackHandler(int pTargetSlot, NonNullList<Slot> pSlots, Pair<Item, Integer>[] pDirectSpec, Vector2i pInventoryRange, Vector2i[] pInventoryOutgoingSpec, Vector2i[] pInventoryIncomingSpec, Pair<Integer, Vector2i> pContainerSpec) {
-        ItemStack modStack = pSlots.get(pTargetSlot).remove(114514);
+        return quickMoveStackHandler(pTargetSlot, pSlots, pDirectSpec, pInventoryRange, pInventoryOutgoingSpec, pInventoryIncomingSpec, pContainerSpec, false);
+    }
+    public static ItemStack quickMoveStackHandler(int pTargetSlot, NonNullList<Slot> pSlots, Pair<Item, Integer>[] pDirectSpec, Vector2i pInventoryRange, Vector2i[] pInventoryOutgoingSpec, Vector2i[] pInventoryIncomingSpec, Pair<Integer, Vector2i> pContainerSpec, boolean useItemHandler) {
+        ItemStack modStack;
+        if (useItemHandler) modStack = pSlots.get(pTargetSlot).remove(114514);
+        else modStack = pSlots.get(pTargetSlot).getItem();
         boolean doContainerLimiting = pContainerSpec != null;
 
         //First we check to see if the slot was within the provided inventory range.


### PR DESCRIPTION
1. returns no handler when not providing a side, just like vanilla furnace
    * to prevent the generic handler overriding whole
2. really pop the testing item to go thru ItemHandler's `extract` once
    * if there's anything wrong, they'll be set back so, alright, hopefully