### PR TITLE
Fixes to cut copper and cut copper stairs + variants distillation out…

### DIFF
--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/cut_copper.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/cut_copper.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:cut_copper" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/cut_copper_stairs.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/cut_copper_stairs.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:cut_copper_stairs" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/exposed_cut_copper.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/exposed_cut_copper.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:exposed_cut_copper" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/exposed_cut_copper_stairs.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/exposed_cut_copper_stairs.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:exposed_cut_copper_stairs" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/oxidized_cut_copper.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/oxidized_cut_copper.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:oxidized_cut_copper" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/oxidized_cut_copper_stairs.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/oxidized_cut_copper_stairs.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:oxidized_cut_copper_stairs" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_cut_copper.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_cut_copper.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:waxed_cut_copper" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_cut_copper_stairs.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_cut_copper_stairs.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:waxed_cut_copper_stairs" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_exposed_cut_copper.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_exposed_cut_copper.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:waxed_exposed_cut_copper" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_exposed_cut_copper_stairs.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_exposed_cut_copper_stairs.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:waxed_exposed_cut_copper_stairs" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_oxidized_cut_copper.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_oxidized_cut_copper.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:waxed_oxidized_cut_copper" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_weathered_cut_copper.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_weathered_cut_copper.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:waxed_weathered_cut_copper" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_weathered_cut_copper_stairs.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/waxed_weathered_cut_copper_stairs.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:waxed_weathered_cut_copper_stairs" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/weathered_cut_copper.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/weathered_cut_copper.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:weathered_cut_copper" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/weathered_cut_copper_stairs.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/weathered_cut_copper_stairs.json
@@ -2,7 +2,7 @@
   "type": "magichem:distillation_fabrication",
   "wisdom": 6,
   "categories": 1,
-  "output_rate": 1.0,
+  "output_rate": 0.5,
   "batch_size": 1,
   "object": { "item": "minecraft:weathered_cut_copper_stairs" },
   "components": [

--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/mna/stone_rune_light_gray.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/mna/stone_rune_light_gray.json
@@ -1,0 +1,13 @@
+{
+  "type": "magichem:distillation_fabrication",
+  "wisdom": 6,
+  "categories": 1,
+  "output_rate": 1.0,
+  "batch_size": 1,
+  "object": { "item": "mna:stone_rune_light_gray" },
+  "components": [
+    { "item": "magichem:admixture_color", "count": 1 },
+    { "item": "magichem:admixture_mana", "count": 1 },
+    { "item": "magichem:admixture_stone", "count": 1 }
+  ]
+}


### PR DESCRIPTION
…puts due to awkward vanilla stone cutter recipes

Adjusted output rate of cut copper and cut copper stairs to 50% due to there being stone cutter recipe creating multiples from 1 block. As opposed to a 1 to 1 craft as most blocks usually are.