### PR TITLE
Fix inconsistencies

### DIFF
--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/cobbled_deepslate_slab.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/minecraft/cobbled_deepslate_slab.json
@@ -1,9 +1,9 @@
 {
   "type": "magichem:distillation_fabrication",
-  "wisdom": 6,
+  "wisdom": 2,
   "categories": 1,
-  "output_rate": 0.5,
-  "batch_size": 1,
+  "output_rate": 0.125,
+  "batch_size": 4,
   "object": { "item": "minecraft:cobbled_deepslate_slab" },
   "components": [
     { "item": "magichem:admixture_stone", "count": 4 },


### PR DESCRIPTION
Cobbled Deepslate Slabs were not fabricable and had an inconsistent output rate with the other deepslate blocks