### PR TITLE
Proposed change for Hexerei Blood Fluid & adding recipe for Blood Bottle

### DIFF
--- a/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/hexerei/blood_bottle.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_distillation_fabrication/hexerei/blood_bottle.json
@@ -1,0 +1,27 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "type": "forge:mod_loaded",
+          "modid": "hexerei"
+        }
+      ],
+      "recipe": {
+        "type": "magichem:distillation_fabrication",
+        "wisdom": 1,
+        "categories": 1,
+        "output_rate": 1.0,
+        "batch_size": 16,
+        "object": {
+          "item": "hexerei:blood_sigil"
+        },
+        "components": [
+          { "item": "magichem:admixture_blood", "count": 2 },
+          { "item": "magichem:admixture_protection", "count": 1 }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/magichem/recipes/alchemical_fluid_distillation_fabrication/hexerei/blood_fluid.json
+++ b/src/main/resources/data/magichem/recipes/alchemical_fluid_distillation_fabrication/hexerei/blood_fluid.json
@@ -11,12 +11,14 @@
       "recipe": {
         "type": "magichem:fluid_distillation_fabrication",
         "wisdom": 1,
-        "categories": 1,
+        "categories": 8,
         "output_rate": 1.0,
         "batch_size": 8,
         "fluid": "hexerei:blood_fluid",
         "components": [
-          { "item": "magichem:admixture_blood", "count": 6 }
+          { "item": "magichem:admixture_blood", "count": 8 },
+		  { "item": "magichem:admixture_protection", "count": 4 }
+		  
         ]
       }
     }


### PR DESCRIPTION
Blood fluid in Hexerei can be distilled but blood bottles cannot. The proposal changes the fluid from 6 AoBlood to 8 to better reflect that you can make 4 bottles of blood at a rate of 250mb. Also bottles of blood provide 6 seconds of absorption which should justify adding AoProtection. Updated blood fluid's category to renewable to reflect the fact that you have to jump like a ninny in a cauldron with a blood sigil to make blood.