### PR TITLE
Add recipe-authored output and input NBT preservation support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ dependencies {
 //    implementation fg.deobf("curse.maven:ars-nouveau-401955:6688854")
     implementation fg.deobf("curse.maven:appleskin-248787:4770828")
 
-    implementation fg.deobf("hexerei:hexerei:0.4.2.3")
+    implementation fg.deobf("curse.maven:hexerei-548599:6314111")
 //    implementation fg.deobf("mekanism:Mekanism-1.20.1:10.4.15.75")
 
     // Example mod dependency with JEI - using fg.deobf() ensures the dependency is remapped to your development mappings

--- a/src/main/java/com/aranaira/magichem/block/entity/AcidBasinBlockEntity.java
+++ b/src/main/java/com/aranaira/magichem/block/entity/AcidBasinBlockEntity.java
@@ -5,6 +5,7 @@ import com.aranaira.magichem.config.ServerConfig;
 import com.aranaira.magichem.foundation.IKeepsInventoryOnBreak;
 import com.aranaira.magichem.foundation.IRequiresRouterCleanupOnDestruction;
 import com.aranaira.magichem.foundation.MagiChemBlockStateProperties;
+import com.aranaira.magichem.recipe.RecipeNbtHelper;
 import com.aranaira.magichem.recipe.VitriolationRecipe;
 import com.aranaira.magichem.registry.BlockEntitiesRegistry;
 import com.aranaira.magichem.registry.BlockRegistry;
@@ -384,11 +385,12 @@ public class AcidBasinBlockEntity extends BlockEntity implements IFluidHandler, 
 
         boolean hasSpaceForOutputItem = true;
         if(recipe.hasResultItem()) {
-            int itemCapacity = recipe.getResultItem().getMaxStackSize() - getOutputItem().getCount();
+            ItemStack resultItem = RecipeNbtHelper.createOutput(recipe, recipe.getResultItem(), getInputItem());
+            int itemCapacity = resultItem.getMaxStackSize() - getOutputItem().getCount();
             boolean itemMatches = getOutputItem().isEmpty()
-                    || ItemStack.isSameItemSameTags(getOutputItem(), recipe.getResultItem());
+                    || ItemStack.isSameItemSameTags(getOutputItem(), resultItem);
 
-            hasSpaceForOutputItem = (itemMatches && itemCapacity >= recipe.getResultItem().getCount());
+            hasSpaceForOutputItem = (itemMatches && itemCapacity >= resultItem.getCount());
         }
 
         return hasInputFluid && hasSpaceForOutputFluid && hasSpaceForOutputItem;
@@ -404,10 +406,11 @@ public class AcidBasinBlockEntity extends BlockEntity implements IFluidHandler, 
         }
 
         if(recipe.hasResultItem()) {
+            ItemStack resultItem = RecipeNbtHelper.createOutput(recipe, recipe.getResultItem(), getInputItem());
             if(getOutputItem().isEmpty()) {
-                itemHandler.setStackInSlot(SLOT_OUTPUT, recipe.getResultItem().copy());
+                itemHandler.setStackInSlot(SLOT_OUTPUT, resultItem);
             } else {
-                getOutputItem().grow(recipe.getResultItem().getCount());
+                getOutputItem().grow(resultItem.getCount());
             }
         }
 

--- a/src/main/java/com/aranaira/magichem/block/entity/AcidBasinBlockEntity.java
+++ b/src/main/java/com/aranaira/magichem/block/entity/AcidBasinBlockEntity.java
@@ -385,7 +385,8 @@ public class AcidBasinBlockEntity extends BlockEntity implements IFluidHandler, 
         boolean hasSpaceForOutputItem = true;
         if(recipe.hasResultItem()) {
             int itemCapacity = recipe.getResultItem().getMaxStackSize() - getOutputItem().getCount();
-            boolean itemMatches = getOutputItem().isEmpty() || (getOutputItem().getItem() == recipe.getResultItem().getItem());
+            boolean itemMatches = getOutputItem().isEmpty()
+                    || ItemStack.isSameItemSameTags(getOutputItem(), recipe.getResultItem());
 
             hasSpaceForOutputItem = (itemMatches && itemCapacity >= recipe.getResultItem().getCount());
         }

--- a/src/main/java/com/aranaira/magichem/block/entity/AlchemicalNexusBlockEntity.java
+++ b/src/main/java/com/aranaira/magichem/block/entity/AlchemicalNexusBlockEntity.java
@@ -90,6 +90,7 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
     protected List<AbstractDirectionalPluginBlockEntity> pluginDevices = new ArrayList<>();
     protected UUID initiatingPlayer = null;
     protected ResourceLocation deferredRecipeQuery = null;
+    protected boolean deferredRecipeQueryIsOutputItem = false;
 
     public static final int
             FLUID_BAR_HEIGHT = 88,
@@ -217,14 +218,20 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
                     if(stack.getItem() == ItemRegistry.SUBLIMATION_IN_PROGRESS.get()) {
                         if(stack.hasTag() && level != null && !level.isClientSide()) {
                             CompoundTag nbt = stack.getTag();
-                            if(nbt.contains("alchemyObject")) {
-                                Item itemQuery = ForgeRegistries.ITEMS.getValue(new ResourceLocation(nbt.getString("alchemyObject")));
-                                SublimationRecipe recipeQuery = SublimationRecipe.getSublimationRecipe(level, itemQuery);
+                            if(nbt.contains("recipeId") || nbt.contains("alchemyObject")) {
+                                SublimationRecipe recipeQuery;
+                                if(nbt.contains("recipeId")) {
+                                    recipeQuery = SublimationRecipe.getSublimationRecipeById(
+                                            level, new ResourceLocation(nbt.getString("recipeId")));
+                                } else {
+                                    Item itemQuery = ForgeRegistries.ITEMS.getValue(new ResourceLocation(nbt.getString("alchemyObject")));
+                                    recipeQuery = itemQuery == null ? null : SublimationRecipe.getSublimationRecipe(level, itemQuery);
+                                }
                                 UUID uuidQuery = initiatingPlayer;
                                 if(nbt.contains("initiatingPlayer"))
                                     uuidQuery = UUID.fromString(nbt.getString("initiatingPlayer"));
 
-                                if(recipeQuery.isForbiddenByAdvancement() && uuidQuery != null) {
+                                if(recipeQuery != null && recipeQuery.isForbiddenByAdvancement() && uuidQuery != null) {
                                     Player playerQuery = level.getPlayerByUUID(uuidQuery);
                                     if(playerQuery instanceof ServerPlayer sp) {
                                         return !AdvancementUtil.serverPlayerHasAdvancement(level, sp, recipeQuery.getForbiddenAdvancement());
@@ -323,9 +330,7 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
         nbt.putBoolean("itemsInTransit", this.itemsInTransit);
 
         if(currentRecipe != null) {
-            ResourceLocation keyQuery = ForgeRegistries.ITEMS.getKey(currentRecipe.getResultItem().getItem());
-            if(keyQuery != null)
-                nbt.putString("recipe", keyQuery.toString());
+            nbt.putString("recipeId", currentRecipe.getId().toString());
         } else {
             nbt.putBoolean("forceRecipeClear", true);
         }
@@ -361,10 +366,18 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
         else
             containedSlurry = FluidStack.EMPTY;
 
-        if(nbt.contains("recipe"))
+        if(nbt.contains("recipeId")) {
+            deferredRecipeQuery = new ResourceLocation(nbt.getString("recipeId"));
+            deferredRecipeQueryIsOutputItem = false;
+        }
+        else if(nbt.contains("recipe")) {
             deferredRecipeQuery = new ResourceLocation(nbt.getString("recipe"));
-        else
+            deferredRecipeQueryIsOutputItem = true;
+        }
+        else {
             deferredRecipeQuery = null;
+            deferredRecipeQueryIsOutputItem = false;
+        }
 
         if(nbt.contains("initiatingPlayer"))
             initiatingPlayer = UUID.fromString(nbt.getString("initiatingPlayer"));
@@ -406,9 +419,7 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
         else
             nbt.putInt("fluidContents", containedSlurry.getAmount());
         if(currentRecipe != null) {
-            ResourceLocation keyQuery = ForgeRegistries.ITEMS.getKey(currentRecipe.getResultItem().getItem());
-            if(keyQuery != null)
-                nbt.putString("recipe", keyQuery.toString());
+            nbt.putString("recipeId", currentRecipe.getId().toString());
         } else {
             nbt.putBoolean("forceRecipeClear", true);
         }
@@ -438,7 +449,7 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
         CompoundTag nbt = new CompoundTag();
 
         if(currentRecipe != null) {
-            nbt.putString("alchemyObject", ForgeRegistries.ITEMS.getKey(currentRecipe.getAlchemyObject().getItem()).toString());
+            nbt.putString("recipeId", currentRecipe.getId().toString());
             nbt.putInt("craftingStage", craftingStage);
             nbt.putInt("animStage", animStage);
             nbt.putInt("remainingFluidForSatisfaction", this.remainingFluidForSatisfaction);
@@ -458,10 +469,15 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
     }
 
     public void unpackCraftDataFromTag(CompoundTag nbt) {
-        if(nbt.contains("alchemyObject")) {
-            Item itemQuery = ForgeRegistries.ITEMS.getValue(new ResourceLocation(nbt.getString("alchemyObject")));
-            if(itemQuery != null && level != null) {
-                SublimationRecipe sr = SublimationRecipe.getSublimationRecipe(level, itemQuery);
+        if(nbt.contains("recipeId") || nbt.contains("alchemyObject")) {
+            if(level != null) {
+                SublimationRecipe sr;
+                if(nbt.contains("recipeId")) {
+                    sr = SublimationRecipe.getSublimationRecipeById(level, new ResourceLocation(nbt.getString("recipeId")));
+                } else {
+                    Item itemQuery = ForgeRegistries.ITEMS.getValue(new ResourceLocation(nbt.getString("alchemyObject")));
+                    sr = itemQuery == null ? null : SublimationRecipe.getSublimationRecipe(level, itemQuery);
+                }
                 if(sr != null) {
                     currentRecipe = sr;
                     cacheAnimSpec(!getLevel().isClientSide());
@@ -613,8 +629,13 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
                     anbe.forceRecipeClear = false;
                     anbe.currentRecipe = null;
                 } else {
-                    Item itemQuery = ForgeRegistries.ITEMS.getValue(anbe.deferredRecipeQuery);
-                    SublimationRecipe recipeQuery = SublimationRecipe.getSublimationRecipe(pLevel, itemQuery);
+                    SublimationRecipe recipeQuery;
+                    if(anbe.deferredRecipeQueryIsOutputItem) {
+                        Item itemQuery = ForgeRegistries.ITEMS.getValue(anbe.deferredRecipeQuery);
+                        recipeQuery = itemQuery == null ? null : SublimationRecipe.getSublimationRecipe(pLevel, itemQuery);
+                    } else {
+                        recipeQuery = SublimationRecipe.getSublimationRecipeById(pLevel, anbe.deferredRecipeQuery);
+                    }
 
                     if (recipeQuery != null) {
                         changed = anbe.currentRecipe != recipeQuery;
@@ -1323,11 +1344,14 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
 
     public void setRecipeFromOutput(Level pLevel, ItemStack pQuery) {
         SublimationRecipe sr = SublimationRecipe.getSublimationRecipe(pLevel, pQuery);
-        if(sr != null && !sr.equals(this.currentRecipe)) {
-            this.currentRecipe = sr;
-            this.craftingStage = 0;
-            this.clearRecipeAfterNextProcess = false;
-            this.syncAndSave();
+        if(sr != null) {
+            this.doDeferredRecipeCheck = false;
+            if(!sr.equals(this.currentRecipe)) {
+                this.currentRecipe = sr;
+                this.craftingStage = 0;
+                this.clearRecipeAfterNextProcess = false;
+                this.syncAndSave();
+            }
         }
     }
 

--- a/src/main/java/com/aranaira/magichem/block/entity/AlchemicalNexusBlockEntity.java
+++ b/src/main/java/com/aranaira/magichem/block/entity/AlchemicalNexusBlockEntity.java
@@ -14,6 +14,7 @@ import com.aranaira.magichem.foundation.enums.ShlorpParticleMode;
 import com.aranaira.magichem.gui.AlchemicalNexusMenu;
 import com.aranaira.magichem.item.MateriaItem;
 import com.aranaira.magichem.item.PhilosophersStoneItem;
+import com.aranaira.magichem.recipe.RecipeNbtHelper;
 import com.aranaira.magichem.recipe.SublimationRecipe;
 import com.aranaira.magichem.registry.*;
 import com.aranaira.magichem.util.AdvancementUtil;
@@ -73,6 +74,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEntity implements MenuProvider, ICanTakePlugins, IFluidHandler, IRequiresRouterCleanupOnDestruction, IMateriaProvisionRequester, IItemProvisionRequester, IHasDeviceRecipeSlot, IKeepsInventoryOnBreak {
+    private static final String NBT_PRESERVED_INPUT = "preservedInput";
 
     protected ItemStackHandler itemHandler;
     protected LazyOptional<IItemHandler> lazyItemHandler = LazyOptional.empty();
@@ -80,6 +82,7 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
 
     protected FluidStack containedSlurry = FluidStack.EMPTY;
     protected SublimationRecipe currentRecipe;
+    protected ItemStack preservedInput = ItemStack.EMPTY;
     protected ContainerData data;
     protected AlchemicalNexusAnimSpec cachedSpec;
     protected int
@@ -334,6 +337,8 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
         } else {
             nbt.putBoolean("forceRecipeClear", true);
         }
+        if(!preservedInput.isEmpty())
+            nbt.put(NBT_PRESERVED_INPUT, preservedInput.serializeNBT());
 
         if(initiatingPlayer != null)
             nbt.putString("initiatingPlayer", initiatingPlayer.toString());
@@ -399,6 +404,9 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
         }
 
         doDeferredRecipeCheck = true;
+        preservedInput = nbt.contains(NBT_PRESERVED_INPUT, CompoundTag.TAG_COMPOUND)
+                ? ItemStack.of(nbt.getCompound(NBT_PRESERVED_INPUT))
+                : ItemStack.EMPTY;
     }
 
     @Override
@@ -423,6 +431,8 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
         } else {
             nbt.putBoolean("forceRecipeClear", true);
         }
+        if(!preservedInput.isEmpty())
+            nbt.put(NBT_PRESERVED_INPUT, preservedInput.serializeNBT());
 
         if(forceDisplayedRecipeUpdate)
             nbt.putBoolean("forceDisplayedRecipeUpdate", true);
@@ -464,11 +474,16 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
             if(initiatingPlayer != null)
                 nbt.putString("initiatingPlayer", initiatingPlayer.toString());
         }
+        if(!preservedInput.isEmpty())
+            nbt.put(NBT_PRESERVED_INPUT, preservedInput.serializeNBT());
 
         return nbt;
     }
 
     public void unpackCraftDataFromTag(CompoundTag nbt) {
+        preservedInput = nbt.contains(NBT_PRESERVED_INPUT, CompoundTag.TAG_COMPOUND)
+                ? ItemStack.of(nbt.getCompound(NBT_PRESERVED_INPUT))
+                : ItemStack.EMPTY;
         if(nbt.contains("recipeId") || nbt.contains("alchemyObject")) {
             if(level != null) {
                 SublimationRecipe sr;
@@ -628,6 +643,7 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
                     changed = true;
                     anbe.forceRecipeClear = false;
                     anbe.currentRecipe = null;
+                    anbe.preservedInput = ItemStack.EMPTY;
                 } else {
                     SublimationRecipe recipeQuery;
                     if(anbe.deferredRecipeQueryIsOutputItem) {
@@ -664,7 +680,7 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
                 {
                     //Check if all the items are present
                     if (anbe.hasAllRecipeItemsForCurrentStage()) {
-                        if (anbe.getContentsOfOutputSlots().canAddItem(anbe.currentRecipe.getAlchemyObject())) {
+                        if (anbe.getContentsOfOutputSlots().canAddItem(anbe.getCraftResult())) {
                             int experienceCost = anbe.currentRecipe.getStages(false).get(anbe.craftingStage).experience * ServerConfig.fluidPerXPPoint;
                             int fluidCost = experienceCost + getBaseExperienceCostPerStage(anbe.getPowerLevel());
 
@@ -717,8 +733,11 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
                     if(!pLevel.isClientSide()) {
                         if (anbe.remainingFluidForSatisfaction <= 0) {
                             anbe.resetProgress();
-                            for (int i = SLOT_INPUT_START; i < SLOT_INPUT_START + SLOT_INPUT_COUNT; i++)
-                                anbe.itemHandler.getStackInSlot(i).shrink(1);
+                            for (int i = SLOT_INPUT_START; i < SLOT_INPUT_START + SLOT_INPUT_COUNT; i++) {
+                                ItemStack input = anbe.itemHandler.getStackInSlot(i);
+                                anbe.capturePreservedInput(input);
+                                input.shrink(1);
+                            }
                             anbe.animStage = ANIM_STAGE_SHLORPS;
                             anbe.createOrUpdateInProgressHolder(anbe.getCraftingStage());
                             anbe.syncAndSave();
@@ -1001,8 +1020,11 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
                     if(anbe.remainingFluidForSatisfaction <= 0) {
                         anbe.remainingFluidForSatisfaction = 0;
                         anbe.resetProgress();
-                        for (int i = SLOT_INPUT_START; i < SLOT_INPUT_START + SLOT_INPUT_COUNT; i++)
-                            anbe.itemHandler.getStackInSlot(i).shrink(1);
+                        for (int i = SLOT_INPUT_START; i < SLOT_INPUT_START + SLOT_INPUT_COUNT; i++) {
+                            ItemStack input = anbe.itemHandler.getStackInSlot(i);
+                            anbe.capturePreservedInput(input);
+                            input.shrink(1);
+                        }
                         anbe.setSatisfactionDemands(anbe.currentRecipe.getStages(true).get(anbe.craftingStage).componentMateria);
                         anbe.animStage = ANIM_STAGE_SHLORPS;
                         anbe.syncAndSave();
@@ -1197,6 +1219,21 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
         return input;
     }
 
+    private void capturePreservedInput(ItemStack input) {
+        if(currentRecipe != null && currentRecipe.getNbtSource() == input.getItem())
+            preservedInput = RecipeNbtHelper.copyOne(input);
+    }
+
+    private ItemStack getCraftResult() {
+        ItemStack source = preservedInput;
+        if(source.isEmpty() && currentRecipe != null && currentRecipe.getNbtSource() != null) {
+            source = getInputItems().stream()
+                    .filter(stack -> stack.getItem() == currentRecipe.getNbtSource())
+                    .findFirst().orElse(ItemStack.EMPTY);
+        }
+        return RecipeNbtHelper.createOutput(currentRecipe, currentRecipe.getAlchemyObject(), source);
+    }
+
     public ItemStack getStoneItem() {
         return itemHandler.getStackInSlot(SLOT_WISDOM);
     }
@@ -1217,7 +1254,7 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
 
     protected void craftItem() {
         SimpleContainer contentsOfOutputSlots = getContentsOfOutputSlots();
-        ItemStack alchemyObject = currentRecipe.getAlchemyObject();
+        ItemStack alchemyObject = getCraftResult();
 
         contentsOfOutputSlots.addItem(alchemyObject.copy());
 
@@ -1237,6 +1274,7 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
         } else {
             setSatisfactionDemands(currentRecipe.getStages(false).get(craftingStage + 1).componentMateria);
         }
+        preservedInput = ItemStack.EMPTY;
     }
 
     protected void createOrUpdateInProgressHolder(int pRecipeStage) {
@@ -1294,6 +1332,8 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
 
         holderNBT.put("savedItems", itemList);
         holderNBT.put("savedMateria", materiaList);
+        if(!preservedInput.isEmpty())
+            holderNBT.put(NBT_PRESERVED_INPUT, preservedInput.serializeNBT());
 
         holder.setTag(holderNBT);
         itemHandler.setStackInSlot(SLOT_PROGRESS_HOLDER, holder);
@@ -1321,12 +1361,14 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
             doDeferredRecipeCheck = false;
             if (animStage == ANIM_STAGE_IDLE) {
                 currentRecipe = null;
+                preservedInput = ItemStack.EMPTY;
                 clearRecipeAfterNextProcess = false;
             }
         } else {
             clearRecipeAfterNextProcess = false;
             doDeferredRecipeCheck = false;
             currentRecipe = null;
+            preservedInput = ItemStack.EMPTY;
         }
         syncAndSave();
     }
@@ -1348,6 +1390,7 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
             this.doDeferredRecipeCheck = false;
             if(!sr.equals(this.currentRecipe)) {
                 this.currentRecipe = sr;
+                this.preservedInput = ItemStack.EMPTY;
                 this.craftingStage = 0;
                 this.clearRecipeAfterNextProcess = false;
                 this.syncAndSave();
@@ -1784,6 +1827,7 @@ public class  AlchemicalNexusBlockEntity extends AbstractMateriaProcessorBlockEn
     public byte setRecipe(ItemStack pStack, Player player) {
         if(pStack.isEmpty()) {
             currentRecipe = null;
+            preservedInput = ItemStack.EMPTY;
             return ERROR_CODE_SUCCESS;
         }
 

--- a/src/main/java/com/aranaira/magichem/block/entity/AstralObserverBlockEntity.java
+++ b/src/main/java/com/aranaira/magichem/block/entity/AstralObserverBlockEntity.java
@@ -11,6 +11,7 @@ import com.aranaira.magichem.foundation.enums.DistilleryRouterType;
 import com.aranaira.magichem.foundation.enums.LuminType;
 import com.aranaira.magichem.gui.AstralObserverMenu;
 import com.aranaira.magichem.recipe.IlluminationRecipe;
+import com.aranaira.magichem.recipe.RecipeNbtHelper;
 import com.aranaira.magichem.registry.BlockEntitiesRegistry;
 import com.aranaira.magichem.registry.BlockRegistry;
 import com.aranaira.magichem.registry.ItemRegistry;
@@ -321,9 +322,11 @@ public class AstralObserverBlockEntity extends BlockEntity implements MenuProvid
             if (recipe != null) {
                 if(pEntity.getLens().getItem() == ItemRegistry.DEBUG_ORB.get()) {
                     IlluminationRecipe recipeFallback = pEntity.getRecipeForPhase(pEntity.luminTypeInItem);
-                    pEntity.heldItem = (recipeFallback == null ? recipe : recipeFallback).getResultItem().copy();
-                    pEntity.luminTypeInItem = (recipeFallback == null ? recipe : recipeFallback).getLuminType();
-                    pEntity.currentLumins = (recipeFallback == null ? recipe : recipeFallback).getCraftTime() * 1200 * ServerConfig.astralObserverLuminGainStandard;
+                    IlluminationRecipe completedRecipe = recipeFallback == null ? recipe : recipeFallback;
+                    pEntity.heldItem = RecipeNbtHelper.createOutput(
+                            completedRecipe, completedRecipe.getResultItem(), pEntity.heldItem, "magichemLumins");
+                    pEntity.luminTypeInItem = completedRecipe.getLuminType();
+                    pEntity.currentLumins = completedRecipe.getCraftTime() * 1200 * ServerConfig.astralObserverLuminGainStandard;
                     pEntity.luminsNeeded = pEntity.currentLumins;
                     pEntity.holdingCompletedCraft = true;
                     pEntity.solarRecipe = null;
@@ -428,7 +431,8 @@ public class AstralObserverBlockEntity extends BlockEntity implements MenuProvid
                             entity.syncAndSave();
                         }
                     } else if (recipeThisPhase != null && entity.currentLumins >= entity.luminsNeeded) {
-                        entity.heldItem = recipeThisPhase.getResultItem().copy();
+                        entity.heldItem = RecipeNbtHelper.createOutput(
+                                recipeThisPhase, recipeThisPhase.getResultItem(), entity.heldItem, "magichemLumins");
                         entity.holdingCompletedCraft = true;
                         entity.solarRecipe = null;
                         entity.lunarRecipe = null;

--- a/src/main/java/com/aranaira/magichem/block/entity/PrimeAggregatorBlockEntity.java
+++ b/src/main/java/com/aranaira/magichem/block/entity/PrimeAggregatorBlockEntity.java
@@ -11,6 +11,7 @@ import com.aranaira.magichem.foundation.enums.PrimeAggregatorRouterType;
 import com.aranaira.magichem.gui.PrimeAggregatorMenu;
 import com.aranaira.magichem.item.MateriaItem;
 import com.aranaira.magichem.recipe.ExaltationRecipe;
+import com.aranaira.magichem.recipe.RecipeNbtHelper;
 import com.aranaira.magichem.registry.BlockEntitiesRegistry;
 import com.aranaira.magichem.registry.FluidRegistry;
 import com.aranaira.magichem.registry.ItemRegistry;
@@ -65,6 +66,8 @@ import java.util.*;
 import static com.mna.api.affinity.Affinity.*;
 
 public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvider, ICanTakePlugins, IFluidHandler, IHasDeviceRecipeSlot, IEldrinConsumerTile, IShlorpReceiver, IMateriaProvisionRequester, IItemProvisionRequester, IRequiresRouterCleanupOnDestruction, IKeepsInventoryOnBreak {
+    private static final String NBT_PRESERVED_INPUT = "preservedInput";
+
     public static final int
             SLOT_COUNT = 7, SLOT_INPUT_COUNT = 2,
             SLOT_ITEM_INPUT = 0, SLOT_MATERIA_INPUT = 1, SLOT_BOTTLES_OUTPUT = 2, SLOT_PROGRESS_HOLDER = 3,
@@ -85,6 +88,7 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
     private final HashMap<Affinity, Float> partialEldrinDelivered = new HashMap<>();
     private boolean doDeferredRecipeCheck = false, itemProvisionInProgress = false;
     private ExaltationRecipe currentRecipe = null;
+    private ItemStack preservedInput = ItemStack.EMPTY;
     private ResourceLocation deferredRecipeQuery = null;
     private boolean deferredRecipeQueryIsOutputItem = false;
     private FluidStack containedSlurry = FluidStack.EMPTY.copy();
@@ -214,11 +218,16 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
                 nbt.put("eldrinDelivered", eldrinDeliveryTag);
             }
         }
+        if(!preservedInput.isEmpty())
+            nbt.put(NBT_PRESERVED_INPUT, preservedInput.serializeNBT());
 
         return nbt;
     }
 
     public void unpackCraftDataFromTag(CompoundTag nbt) {
+        preservedInput = nbt.contains(NBT_PRESERVED_INPUT, CompoundTag.TAG_COMPOUND)
+                ? ItemStack.of(nbt.getCompound(NBT_PRESERVED_INPUT))
+                : ItemStack.EMPTY;
         if(nbt.contains("recipeId") || nbt.contains("result")) {
             if(level != null) {
                 ExaltationRecipe er;
@@ -317,6 +326,7 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
         if(er != null) {
             this.doDeferredRecipeCheck = false;
             this.currentRecipe = er;
+            this.preservedInput = ItemStack.EMPTY;
             this.clearDeliveries();
             this.animStage = ANIM_STAGE_IDLE;
             this.syncAndSave();
@@ -330,6 +340,7 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
         }
 
         this.currentRecipe = null;
+        this.preservedInput = ItemStack.EMPTY;
         this.clearDeliveries();
         this.animStage = ANIM_STAGE_IDLE;
         this.syncAndSave();
@@ -376,6 +387,8 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
         if(currentRecipe != null) {
             nbt.putString("recipeId", currentRecipe.getId().toString());
         }
+        if(!preservedInput.isEmpty())
+            nbt.put(NBT_PRESERVED_INPUT, preservedInput.serializeNBT());
 
         CompoundTag deliveryTag = new CompoundTag();
         deliveryTag.putInt("items", itemsDelivered);
@@ -458,6 +471,9 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
         }
 
         itemProvisionInProgress = nbt.getBoolean("itemProvisionInProgress");
+        preservedInput = nbt.contains(NBT_PRESERVED_INPUT, CompoundTag.TAG_COMPOUND)
+                ? ItemStack.of(nbt.getCompound(NBT_PRESERVED_INPUT))
+                : ItemStack.EMPTY;
 
 //        updateActuatorValues(this);
     }
@@ -478,6 +494,8 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
         if(currentRecipe != null) {
             nbt.putString("recipeId", currentRecipe.getId().toString());
         }
+        if(!preservedInput.isEmpty())
+            nbt.put(NBT_PRESERVED_INPUT, preservedInput.serializeNBT());
 
         CompoundTag deliveryTag = new CompoundTag();
         deliveryTag.putInt("items", itemsDelivered);
@@ -704,6 +722,7 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
             } else {
                 changed = pEntity.currentRecipe != null;
                 pEntity.currentRecipe = null;
+                pEntity.preservedInput = ItemStack.EMPTY;
             }
             pEntity.doDeferredRecipeCheck = false;
             if(changed)
@@ -1049,6 +1068,8 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
 
                             if (extraction > 0) {
                                 pEntity.itemsDelivered += extraction;
+                                if(pEntity.currentRecipe.getNbtSource() == itemQuery.getItem())
+                                    pEntity.preservedInput = RecipeNbtHelper.copyOne(itemQuery);
                                 itemQuery.shrink(extraction);
                                 changed = true;
 
@@ -1199,14 +1220,15 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
 
     private boolean canCraftItem() {
         SimpleContainer output = getContentsOfOutputSlots();
+        ItemStack result = RecipeNbtHelper.createOutput(currentRecipe, currentRecipe.getResultItem(), preservedInput);
         boolean valid = false;
 
         for(int i=0; i<output.getContainerSize(); i++) {
             ItemStack query = output.getItem(i);
             if(query.isEmpty()) valid = true;
-            else if(ItemStack.isSameItemSameTags(query, currentRecipe.getResultItem())) {
-                int space = currentRecipe.getResultItem().getMaxStackSize() - query.getCount();
-                valid = space >= currentRecipe.getResultItem().getCount();
+            else if(ItemStack.isSameItemSameTags(query, result)) {
+                int space = result.getMaxStackSize() - query.getCount();
+                valid = space >= result.getCount();
             }
 
             if(valid) break;
@@ -1217,11 +1239,12 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
 
     private void craftItem() {
         SimpleContainer output = getContentsOfOutputSlots();
-        output.addItem(currentRecipe.getResultItem().copy());
+        output.addItem(RecipeNbtHelper.createOutput(currentRecipe, currentRecipe.getResultItem(), preservedInput));
 
         for(int i=0; i<SLOT_OUTPUT_COUNT; i++) {
             itemHandler.setStackInSlot(SLOT_OUTPUT_START+i, output.getItem(i));
         }
+        preservedInput = ItemStack.EMPTY;
     }
 
     ////////////////////
@@ -1446,6 +1469,7 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
         } else {
             this.doDeferredRecipeCheck = false;
             this.currentRecipe = recipeQuery;
+            this.preservedInput = ItemStack.EMPTY;
             this.clearDeliveries();
             this.animStage = ANIM_STAGE_IDLE;
             this.syncAndSave();

--- a/src/main/java/com/aranaira/magichem/block/entity/PrimeAggregatorBlockEntity.java
+++ b/src/main/java/com/aranaira/magichem/block/entity/PrimeAggregatorBlockEntity.java
@@ -86,6 +86,7 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
     private boolean doDeferredRecipeCheck = false, itemProvisionInProgress = false;
     private ExaltationRecipe currentRecipe = null;
     private ResourceLocation deferredRecipeQuery = null;
+    private boolean deferredRecipeQueryIsOutputItem = false;
     private FluidStack containedSlurry = FluidStack.EMPTY.copy();
     protected List<AbstractDirectionalPluginBlockEntity> pluginDevices = new ArrayList<>();
 
@@ -201,7 +202,7 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
 
         if(currentRecipe != null) {
             if(existingAnimStage <= animStage){
-                nbt.putString("result", ForgeRegistries.ITEMS.getKey(currentRecipe.getResultItem().getItem()).toString());
+                nbt.putString("recipeId", currentRecipe.getId().toString());
                 nbt.putInt("animStage", animStage);
                 nbt.putInt("itemsDelivered", itemsDelivered);
                 nbt.putInt("materiaDelivered", materiaDelivered);
@@ -218,10 +219,15 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
     }
 
     public void unpackCraftDataFromTag(CompoundTag nbt) {
-        if(nbt.contains("result")) {
-            Item itemQuery = ForgeRegistries.ITEMS.getValue(new ResourceLocation(nbt.getString("result")));
-            if(itemQuery != null && level != null) {
-                ExaltationRecipe er = ExaltationRecipe.getExaltationRecipe(level, itemQuery);
+        if(nbt.contains("recipeId") || nbt.contains("result")) {
+            if(level != null) {
+                ExaltationRecipe er;
+                if(nbt.contains("recipeId")) {
+                    er = ExaltationRecipe.getExaltationRecipeById(level, new ResourceLocation(nbt.getString("recipeId")));
+                } else {
+                    Item itemQuery = ForgeRegistries.ITEMS.getValue(new ResourceLocation(nbt.getString("result")));
+                    er = itemQuery == null ? null : ExaltationRecipe.getExaltationRecipe(level, itemQuery);
+                }
                 if(er != null) {
                     currentRecipe = er;
                     doDeferredRecipeCheck = false;
@@ -301,12 +307,15 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
     }
 
     public void setRecipeByOutput(ItemStack pRecipeOutput) {
-        if(currentRecipe != null && pRecipeOutput.getItem() == currentRecipe.getResultItem().getItem())
+        if(currentRecipe != null && ItemStack.isSameItemSameTags(pRecipeOutput, currentRecipe.getResultItem())) {
+            doDeferredRecipeCheck = false;
             return;
+        }
 
-        ExaltationRecipe er = ExaltationRecipe.getExaltationRecipe(level, pRecipeOutput.getItem());
+        ExaltationRecipe er = ExaltationRecipe.getExaltationRecipe(level, pRecipeOutput);
 
         if(er != null) {
+            this.doDeferredRecipeCheck = false;
             this.currentRecipe = er;
             this.clearDeliveries();
             this.animStage = ANIM_STAGE_IDLE;
@@ -365,9 +374,7 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
             nbt.putUUID("owner", ownerUUID);
 
         if(currentRecipe != null) {
-            ResourceLocation keyQuery = ForgeRegistries.ITEMS.getKey(currentRecipe.getResultItem().getItem());
-            if(keyQuery != null)
-                nbt.putString("recipe", keyQuery.toString());
+            nbt.putString("recipeId", currentRecipe.getId().toString());
         }
 
         CompoundTag deliveryTag = new CompoundTag();
@@ -414,10 +421,18 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
         else
             containedSlurry = FluidStack.EMPTY;
 
-        if(nbt.contains("recipe"))
+        if(nbt.contains("recipeId")) {
+            deferredRecipeQuery = new ResourceLocation(nbt.getString("recipeId"));
+            deferredRecipeQueryIsOutputItem = false;
+        }
+        else if(nbt.contains("recipe")) {
             deferredRecipeQuery = new ResourceLocation(nbt.getString("recipe"));
-        else
+            deferredRecipeQueryIsOutputItem = true;
+        }
+        else {
             deferredRecipeQuery = null;
+            deferredRecipeQueryIsOutputItem = false;
+        }
         doDeferredRecipeCheck = true;
 
         CompoundTag deliveryTag = nbt.getCompound("deliveries");
@@ -461,9 +476,7 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
             nbt.putUUID("owner", ownerUUID);
 
         if(currentRecipe != null) {
-            ResourceLocation keyQuery = ForgeRegistries.ITEMS.getKey(currentRecipe.getResultItem().getItem());
-            if(keyQuery != null)
-                nbt.putString("recipe", keyQuery.toString());
+            nbt.putString("recipeId", currentRecipe.getId().toString());
         }
 
         CompoundTag deliveryTag = new CompoundTag();
@@ -677,8 +690,13 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
 
         if(pEntity.doDeferredRecipeCheck) {
             boolean changed;
-            Item itemQuery = ForgeRegistries.ITEMS.getValue(pEntity.deferredRecipeQuery);
-            ExaltationRecipe recipeQuery = ExaltationRecipe.getExaltationRecipe(pLevel, itemQuery);
+            ExaltationRecipe recipeQuery;
+            if(pEntity.deferredRecipeQueryIsOutputItem) {
+                Item itemQuery = ForgeRegistries.ITEMS.getValue(pEntity.deferredRecipeQuery);
+                recipeQuery = itemQuery == null ? null : ExaltationRecipe.getExaltationRecipe(pLevel, itemQuery);
+            } else {
+                recipeQuery = ExaltationRecipe.getExaltationRecipeById(pLevel, pEntity.deferredRecipeQuery);
+            }
 
             if(recipeQuery != null) {
                 changed = pEntity.currentRecipe != recipeQuery;
@@ -1186,7 +1204,7 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
         for(int i=0; i<output.getContainerSize(); i++) {
             ItemStack query = output.getItem(i);
             if(query.isEmpty()) valid = true;
-            else if(query.getItem() == currentRecipe.getResultItem().getItem()) {
+            else if(ItemStack.isSameItemSameTags(query, currentRecipe.getResultItem())) {
                 int space = currentRecipe.getResultItem().getMaxStackSize() - query.getCount();
                 valid = space >= currentRecipe.getResultItem().getCount();
             }
@@ -1418,13 +1436,15 @@ public class PrimeAggregatorBlockEntity extends BlockEntity implements MenuProvi
     public byte setRecipe(ItemStack pStack, Player player) {
         if(pStack.isEmpty()) clearRecipe();
         ExaltationRecipe recipePre = currentRecipe;
-        ExaltationRecipe recipeQuery = ExaltationRecipe.getExaltationRecipe(level, pStack.getItem());
+        ExaltationRecipe recipeQuery = ExaltationRecipe.getExaltationRecipe(level, pStack);
 
         if(recipeQuery == null) {
             return ERROR_CODE_NO_SUCH_RECIPE;
         } else if(recipePre == recipeQuery) {
+            doDeferredRecipeCheck = false;
             return ERROR_CODE_SUCCESS;
         } else {
+            this.doDeferredRecipeCheck = false;
             this.currentRecipe = recipeQuery;
             this.clearDeliveries();
             this.animStage = ANIM_STAGE_IDLE;

--- a/src/main/java/com/aranaira/magichem/gui/PrimeAggregatorScreen.java
+++ b/src/main/java/com/aranaira/magichem/gui/PrimeAggregatorScreen.java
@@ -152,7 +152,7 @@ public class PrimeAggregatorScreen extends AbstractContainerScreen<PrimeAggregat
         if(trueIndex < filteredRecipes.size()) {
             PacketRegistry.sendToServer(new DeviceRecipeSyncDataC2SPacket(
                     menu.blockEntity.getBlockPos(),
-                    filteredRecipes.get(trueIndex).getItem()
+                    filteredRecipes.get(trueIndex)
             ));
         }
     }

--- a/src/main/java/com/aranaira/magichem/networking/DeviceRecipeSyncDataC2SPacket.java
+++ b/src/main/java/com/aranaira/magichem/networking/DeviceRecipeSyncDataC2SPacket.java
@@ -13,24 +13,25 @@ import java.util.function.Supplier;
 
 public class DeviceRecipeSyncDataC2SPacket {
     private final BlockPos blockPos;
-    private final Item recipeItem;
+    private final ItemStack recipeOutput;
 
     public DeviceRecipeSyncDataC2SPacket(BlockPos pBlockPos, Item pRecipeItem) {
+        this(pBlockPos, pRecipeItem == null ? ItemStack.EMPTY : new ItemStack(pRecipeItem));
+    }
+
+    public DeviceRecipeSyncDataC2SPacket(BlockPos pBlockPos, ItemStack pRecipeOutput) {
         this.blockPos = pBlockPos;
-        this.recipeItem = pRecipeItem;
+        this.recipeOutput = pRecipeOutput.copy();
     }
 
     public DeviceRecipeSyncDataC2SPacket(FriendlyByteBuf buf) {
         this.blockPos = buf.readBlockPos();
-        this.recipeItem = buf.readItem().getItem();
+        this.recipeOutput = buf.readItem();
     }
 
     public void toBytes(FriendlyByteBuf buf) {
         buf.writeBlockPos(blockPos);
-        if(recipeItem == null)
-            buf.writeItem(ItemStack.EMPTY);
-        else
-            buf.writeItem(new ItemStack(recipeItem, 1));
+        buf.writeItemStack(recipeOutput, true);
     }
 
     public boolean handle(Supplier<NetworkEvent.Context> supplier) {
@@ -41,19 +42,19 @@ public class DeviceRecipeSyncDataC2SPacket {
 
         context.enqueueWork(() -> {
             if(entity instanceof FuseryBlockEntity fusery) {
-                fusery.setRecipeByOutput(new ItemStack(recipeItem));
+                fusery.setRecipeByOutput(recipeOutput.copy());
             }
             else if(entity instanceof GrandFuseryBlockEntity fusery) {
-                fusery.setRecipeByOutput(new ItemStack(recipeItem));
+                fusery.setRecipeByOutput(recipeOutput.copy());
             }
             else if(entity instanceof CentrifugeBlockEntity centrifuge) {
-                centrifuge.setRecipeByOutput(new ItemStack(recipeItem));
+                centrifuge.setRecipeByOutput(recipeOutput.copy());
             }
             else if(entity instanceof GrandCentrifugeBlockEntity centrifuge) {
-                centrifuge.setRecipeByOutput(new ItemStack(recipeItem));
+                centrifuge.setRecipeByOutput(recipeOutput.copy());
             }
             else if(entity instanceof PrimeAggregatorBlockEntity aggregator) {
-                aggregator.setRecipeByOutput(new ItemStack(recipeItem));
+                aggregator.setRecipeByOutput(recipeOutput.copy());
             }
         });
 

--- a/src/main/java/com/aranaira/magichem/recipe/ExaltationRecipe.java
+++ b/src/main/java/com/aranaira/magichem/recipe/ExaltationRecipe.java
@@ -27,19 +27,26 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-public class ExaltationRecipe implements Recipe<SimpleContainer>, IMARecipe {
+public class ExaltationRecipe implements Recipe<SimpleContainer>, IMARecipe, NbtPreservingRecipe {
     public static final int
         ENDER = 1, EARTH = 2, WATER = 4, AIR = 8, FIRE = 16, ARCANE = 32;
 
     private final ResourceLocation id;
     private final ItemStack result;
     private final Item itemType;
+    @Nullable
+    private final Item nbtSource;
     private final MateriaItem materiaType;
     private final int itemsRequired, materiaRequired, slurryRequired, eldrinRequired;
     private final byte tier, wisdom, eldrinType;
     private ItemStack itemAsStack = ItemStack.EMPTY, materiaAsStack = ItemStack.EMPTY;
 
     public ExaltationRecipe(ResourceLocation pID, ItemStack pResult, byte pTier, byte pWisdom, Item pItemType, int pItemsRequired, MateriaItem pMateriaType, int pMateriaRequired, byte pEldrinType, int pEldrinRequired, int pSlurryRequired) {
+        this(pID, pResult, pTier, pWisdom, pItemType, pItemsRequired, pMateriaType, pMateriaRequired,
+                pEldrinType, pEldrinRequired, pSlurryRequired, null);
+    }
+
+    public ExaltationRecipe(ResourceLocation pID, ItemStack pResult, byte pTier, byte pWisdom, Item pItemType, int pItemsRequired, MateriaItem pMateriaType, int pMateriaRequired, byte pEldrinType, int pEldrinRequired, int pSlurryRequired, @Nullable Item pNbtSource) {
         this.id = pID;
         this.result = pResult;
         this.tier = pTier;
@@ -51,6 +58,7 @@ public class ExaltationRecipe implements Recipe<SimpleContainer>, IMARecipe {
         this.eldrinType = pEldrinType;
         this.eldrinRequired = pEldrinRequired;
         this.slurryRequired = pSlurryRequired;
+        this.nbtSource = pNbtSource;
 
         this.itemAsStack = new ItemStack(pItemType);
         this.materiaAsStack = new ItemStack(pMateriaType);
@@ -76,6 +84,11 @@ public class ExaltationRecipe implements Recipe<SimpleContainer>, IMARecipe {
 
     public Item getItemType() {
         return itemType;
+    }
+
+    @Override
+    public @Nullable Item getNbtSource() {
+        return nbtSource;
     }
 
     public int getItemsRequired() {
@@ -310,7 +323,17 @@ public class ExaltationRecipe implements Recipe<SimpleContainer>, IMARecipe {
                 eldrinRequired = GsonHelper.getAsInt(eldrinObject, "required");
             }
 
-            return new ExaltationRecipe(pRecipeId, result, tier, wisdom, itemType, itemsRequired, materiaType, materiaRequired, eldrinType, eldrinRequired, slurryRequired);
+            Item nbtSource = null;
+            if(RecipeNbtHelper.readOptionalBoolean(pSerializedRecipe, pRecipeId)) {
+                if(itemsRequired != 1)
+                    throw RecipeNbtHelper.error(pRecipeId, "the exaltation item input count must be exactly one");
+                if(result.getCount() != 1)
+                    throw RecipeNbtHelper.error(pRecipeId, "the output count must be exactly one");
+                nbtSource = itemType;
+            }
+
+            return new ExaltationRecipe(pRecipeId, result, tier, wisdom, itemType, itemsRequired, materiaType,
+                    materiaRequired, eldrinType, eldrinRequired, slurryRequired, nbtSource);
         }
 
         @Override
@@ -336,8 +359,10 @@ public class ExaltationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             int eldrinRequired = eldrinTag.getInt("required");
 
             int slurryRequired = nbt.getInt("slurry");
+            Item nbtSource = RecipeNbtHelper.readNetworkSource(nbt);
 
-            return new ExaltationRecipe(pRecipeId, result, tier, wisdom, itemType, itemsRequired, materiaType, materiaRequired, eldrinType, eldrinRequired, slurryRequired);
+            return new ExaltationRecipe(pRecipeId, result, tier, wisdom, itemType, itemsRequired, materiaType,
+                    materiaRequired, eldrinType, eldrinRequired, slurryRequired, nbtSource);
         }
 
         @Override
@@ -364,6 +389,7 @@ public class ExaltationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             nbt.put("eldrin", eldrinTag);
 
             nbt.putInt("slurry", pRecipe.slurryRequired);
+            RecipeNbtHelper.writeNetworkSource(nbt, pRecipe);
 
             pBuffer.writeNbt(nbt);
         }

--- a/src/main/java/com/aranaira/magichem/recipe/ExaltationRecipe.java
+++ b/src/main/java/com/aranaira/magichem/recipe/ExaltationRecipe.java
@@ -179,6 +179,28 @@ public class ExaltationRecipe implements Recipe<SimpleContainer>, IMARecipe {
         return recipeResult;
     }
 
+    public static ExaltationRecipe getExaltationRecipe(Level level, ItemStack query) {
+        if(query == null || query.isEmpty()) return null;
+
+        for(ExaltationRecipe recipe : level.getRecipeManager().getAllRecipesFor(Type.INSTANCE)) {
+            if(ItemStack.isSameItemSameTags(recipe.result, query))
+                return recipe;
+        }
+
+        return null;
+    }
+
+    public static ExaltationRecipe getExaltationRecipeById(Level level, ResourceLocation id) {
+        if(id == null) return null;
+
+        for(ExaltationRecipe recipe : level.getRecipeManager().getAllRecipesFor(Type.INSTANCE)) {
+            if(recipe.getId().equals(id))
+                return recipe;
+        }
+
+        return null;
+    }
+
     public static List<ExaltationRecipe> getAllExaltationRecipes(Level level) {
         return level.getRecipeManager().getAllRecipesFor(Type.INSTANCE);
     }
@@ -252,6 +274,7 @@ public class ExaltationRecipe implements Recipe<SimpleContainer>, IMARecipe {
                 }
                 else {
                     result = new ItemStack(item, count);
+                    RecipeOutputHelper.applyNbt(result, resultObject, pRecipeId);
                 }
             }
 

--- a/src/main/java/com/aranaira/magichem/recipe/IlluminationRecipe.java
+++ b/src/main/java/com/aranaira/magichem/recipe/IlluminationRecipe.java
@@ -171,9 +171,12 @@ public class IlluminationRecipe implements Recipe<SimpleContainer>, IMARecipe {
                     resultItemAsItem = ItemRegistry.PROBLEMITE.get();
             }
 
+            ItemStack resultItem = RecipeOutputHelper.applyNbt(
+                    new ItemStack(resultItemAsItem, resultItemCount), resultItemObject, pRecipeId);
+
             return new IlluminationRecipe(pRecipeId,
                     new ItemStack(inputItemAsItem),
-                    new ItemStack(resultItemAsItem, resultItemCount),
+                    resultItem,
                     luminTypeAsType, craftTime
             );
         }
@@ -192,13 +195,11 @@ public class IlluminationRecipe implements Recipe<SimpleContainer>, IMARecipe {
 
             int craftTime = nbt.getInt("minutes");
 
-            CompoundTag resultItemTag = nbt.getCompound("resultItem");
-            Item resultItemAsItem = ForgeRegistries.ITEMS.getValue(new ResourceLocation(resultItemTag.getString("item")));
-            int resultItemCount = resultItemTag.getInt("count");
+            ItemStack resultItem = ItemStack.of(nbt.getCompound("resultItem"));
 
             return new IlluminationRecipe(pRecipeId,
                     inputAsItem == null ? ItemStack.EMPTY : new ItemStack(inputAsItem),
-                    resultItemAsItem == null ? ItemStack.EMPTY : new ItemStack(resultItemAsItem, resultItemCount),
+                    resultItem,
                     luminTypeAsType, craftTime
             );
         }
@@ -211,10 +212,7 @@ public class IlluminationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             nbt.putInt("luminType",pRecipe.luminType.ordinal());
             nbt.putInt("minutes",pRecipe.craftTime);
 
-            CompoundTag resultItemTag = new CompoundTag();
-            resultItemTag.putString("item", ForgeRegistries.ITEMS.getKey(pRecipe.resultItem.getItem()).toString());
-            resultItemTag.putInt("count", pRecipe.resultItem.getCount());
-            nbt.put("resultItem", resultItemTag);
+            nbt.put("resultItem", pRecipe.resultItem.serializeNBT());
 
             pBuffer.writeNbt(nbt);
         }

--- a/src/main/java/com/aranaira/magichem/recipe/IlluminationRecipe.java
+++ b/src/main/java/com/aranaira/magichem/recipe/IlluminationRecipe.java
@@ -23,18 +23,25 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class IlluminationRecipe implements Recipe<SimpleContainer>, IMARecipe {
+public class IlluminationRecipe implements Recipe<SimpleContainer>, IMARecipe, NbtPreservingRecipe {
     private final ResourceLocation id;
     private final ItemStack inputItem, resultItem;
     private final LuminType luminType;
+    @Nullable
+    private final Item nbtSource;
     private final int craftTime;
 
     public IlluminationRecipe(ResourceLocation pID, ItemStack pInputItem, ItemStack pResultItem, LuminType pLuminType, int pCraftTime) {
+        this(pID, pInputItem, pResultItem, pLuminType, pCraftTime, null);
+    }
+
+    public IlluminationRecipe(ResourceLocation pID, ItemStack pInputItem, ItemStack pResultItem, LuminType pLuminType, int pCraftTime, @Nullable Item pNbtSource) {
         this.id = pID;
         this.inputItem = pInputItem;
         this.resultItem = pResultItem;
         this.luminType = pLuminType;
         this.craftTime = pCraftTime;
+        this.nbtSource = pNbtSource;
     }
 
     @Override
@@ -49,6 +56,11 @@ public class IlluminationRecipe implements Recipe<SimpleContainer>, IMARecipe {
 
     public ItemStack getInputItem() {
         return inputItem;
+    }
+
+    @Override
+    public @Nullable Item getNbtSource() {
+        return nbtSource;
     }
 
     @Override
@@ -174,10 +186,18 @@ public class IlluminationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             ItemStack resultItem = RecipeOutputHelper.applyNbt(
                     new ItemStack(resultItemAsItem, resultItemCount), resultItemObject, pRecipeId);
 
+            Item nbtSource = null;
+            if(RecipeNbtHelper.readOptionalBoolean(pSerializedRecipe, pRecipeId)) {
+                if(resultItem.getCount() != 1)
+                    throw RecipeNbtHelper.error(pRecipeId,
+                            "illumination input and output counts must both be exactly one");
+                nbtSource = inputItemAsItem;
+            }
+
             return new IlluminationRecipe(pRecipeId,
                     new ItemStack(inputItemAsItem),
                     resultItem,
-                    luminTypeAsType, craftTime
+                    luminTypeAsType, craftTime, nbtSource
             );
         }
 
@@ -196,11 +216,12 @@ public class IlluminationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             int craftTime = nbt.getInt("minutes");
 
             ItemStack resultItem = ItemStack.of(nbt.getCompound("resultItem"));
+            Item nbtSource = RecipeNbtHelper.readNetworkSource(nbt);
 
             return new IlluminationRecipe(pRecipeId,
                     inputAsItem == null ? ItemStack.EMPTY : new ItemStack(inputAsItem),
                     resultItem,
-                    luminTypeAsType, craftTime
+                    luminTypeAsType, craftTime, nbtSource
             );
         }
 
@@ -213,6 +234,7 @@ public class IlluminationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             nbt.putInt("minutes",pRecipe.craftTime);
 
             nbt.put("resultItem", pRecipe.resultItem.serializeNBT());
+            RecipeNbtHelper.writeNetworkSource(nbt, pRecipe);
 
             pBuffer.writeNbt(nbt);
         }

--- a/src/main/java/com/aranaira/magichem/recipe/NbtPreservingRecipe.java
+++ b/src/main/java/com/aranaira/magichem/recipe/NbtPreservingRecipe.java
@@ -1,0 +1,9 @@
+package com.aranaira.magichem.recipe;
+
+import net.minecraft.world.item.Item;
+import org.jetbrains.annotations.Nullable;
+
+public interface NbtPreservingRecipe {
+    @Nullable
+    Item getNbtSource();
+}

--- a/src/main/java/com/aranaira/magichem/recipe/RecipeNbtHelper.java
+++ b/src/main/java/com/aranaira/magichem/recipe/RecipeNbtHelper.java
@@ -1,0 +1,90 @@
+package com.aranaira.magichem.recipe;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.Nullable;
+
+public final class RecipeNbtHelper {
+    private static final String JSON_KEY = "preserve_nbt";
+    private static final String NETWORK_KEY = "preserveNbtSource";
+
+    private RecipeNbtHelper() {
+    }
+
+    public static boolean readOptionalBoolean(JsonObject recipeJson, ResourceLocation recipeId) {
+        if(!recipeJson.has(JSON_KEY)) return false;
+
+        JsonElement element = recipeJson.get(JSON_KEY);
+        if(!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isBoolean())
+            throw error(recipeId, "'preserve_nbt' must be a boolean");
+
+        return element.getAsBoolean();
+    }
+
+    @Nullable
+    public static Item readOptionalSource(JsonObject recipeJson, ResourceLocation recipeId) {
+        if(!recipeJson.has(JSON_KEY)) return null;
+
+        JsonElement element = recipeJson.get(JSON_KEY);
+        if(!element.isJsonObject())
+            throw error(recipeId, "'preserve_nbt' must be an object containing an 'item'");
+
+        JsonObject object = element.getAsJsonObject();
+        if(!object.has("item") || !object.get("item").isJsonPrimitive())
+            throw error(recipeId, "'preserve_nbt.item' must be a concrete item id");
+
+        ResourceLocation id = ResourceLocation.tryParse(object.get("item").getAsString());
+        Item source = id == null ? null : ForgeRegistries.ITEMS.getValue(id);
+        if(source == null || !ForgeRegistries.ITEMS.containsKey(id))
+            throw error(recipeId, "unknown preserve_nbt item '" + object.get("item").getAsString() + "'");
+
+        return source;
+    }
+
+    public static void writeNetworkSource(CompoundTag nbt, NbtPreservingRecipe recipe) {
+        Item source = recipe.getNbtSource();
+        ResourceLocation id = source == null ? null : ForgeRegistries.ITEMS.getKey(source);
+        if(id != null) nbt.putString(NETWORK_KEY, id.toString());
+    }
+
+    @Nullable
+    public static Item readNetworkSource(CompoundTag nbt) {
+        if(!nbt.contains(NETWORK_KEY, CompoundTag.TAG_STRING)) return null;
+
+        ResourceLocation id = ResourceLocation.tryParse(nbt.getString(NETWORK_KEY));
+        if(id == null || !ForgeRegistries.ITEMS.containsKey(id)) return null;
+        return ForgeRegistries.ITEMS.getValue(id);
+    }
+
+    public static ItemStack createOutput(NbtPreservingRecipe recipe, ItemStack recipeOutput,
+                                         ItemStack source, String... transientKeys) {
+        Item expectedSource = recipe.getNbtSource();
+        if(expectedSource == null || source.isEmpty() || source.getItem() != expectedSource)
+            return recipeOutput.copy();
+
+        ItemStack result = recipeOutput.copy();
+        CompoundTag outputNbt = result.getTag() == null ? null : result.getTag().copy();
+        CompoundTag mergedNbt = source.getTag() == null ? new CompoundTag() : source.getTag().copy();
+        if(outputNbt != null) mergedNbt.merge(outputNbt);
+        for(String key : transientKeys) mergedNbt.remove(key);
+
+        result.setTag(mergedNbt.isEmpty() ? null : mergedNbt);
+        return result;
+    }
+
+    public static ItemStack copyOne(ItemStack source) {
+        ItemStack copy = source.copy();
+        copy.setCount(1);
+        return copy;
+    }
+
+    public static JsonSyntaxException error(ResourceLocation recipeId, String message) {
+        return new JsonSyntaxException("Invalid NBT-preserving MagiChem recipe '" + recipeId + "': " + message);
+    }
+}

--- a/src/main/java/com/aranaira/magichem/recipe/RecipeOutputHelper.java
+++ b/src/main/java/com/aranaira/magichem/recipe/RecipeOutputHelper.java
@@ -1,0 +1,28 @@
+package com.aranaira.magichem.recipe;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.nbt.TagParser;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.item.ItemStack;
+
+final class RecipeOutputHelper {
+    private RecipeOutputHelper() {
+    }
+
+    static ItemStack applyNbt(ItemStack output, JsonObject outputJson, ResourceLocation recipeId) {
+        if(output.isEmpty() || outputJson == null || !outputJson.has("nbt"))
+            return output;
+
+        String serializedNbt = GsonHelper.getAsString(outputJson, "nbt");
+        try {
+            output.setTag(TagParser.parseTag(serializedNbt));
+        } catch(CommandSyntaxException exception) {
+            throw new JsonSyntaxException("Invalid output NBT in MagiChem recipe '" + recipeId + "': " + exception.getMessage(), exception);
+        }
+
+        return output;
+    }
+}

--- a/src/main/java/com/aranaira/magichem/recipe/SublimationRecipe.java
+++ b/src/main/java/com/aranaira/magichem/recipe/SublimationRecipe.java
@@ -164,7 +164,14 @@ public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
     }
 
     public static SublimationRecipe getSublimationRecipe(Level level, ItemStack query) {
-        return getSublimationRecipe(level, query.getItem());
+        if(query == null || query.isEmpty()) return null;
+
+        for(SublimationRecipe recipe : level.getRecipeManager().getAllRecipesFor(Type.INSTANCE)) {
+            if(ItemStack.isSameItemSameTags(recipe.alchemyObject, query))
+                return recipe;
+        }
+
+        return null;
     }
 
     public static SublimationRecipe getSublimationRecipe(Level level, Item query) {
@@ -179,6 +186,17 @@ public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
         }
 
         return result;
+    }
+
+    public static SublimationRecipe getSublimationRecipeById(Level level, ResourceLocation id) {
+        if(id == null) return null;
+
+        for(SublimationRecipe recipe : level.getRecipeManager().getAllRecipesFor(Type.INSTANCE)) {
+            if(recipe.getId().equals(id))
+                return recipe;
+        }
+
+        return null;
     }
 
     public static NonNullList<ItemStack> getAllOutputs(Level pLevel) {
@@ -219,6 +237,7 @@ public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
                 Item outputQuery = ForgeRegistries.ITEMS.getValue(new ResourceLocation(key));
                 if(outputQuery != null && outputQuery != Items.AIR) {
                     recipeStack = new ItemStack(outputQuery, count);
+                    RecipeOutputHelper.applyNbt(recipeStack, recipeObject, pRecipeId);
                 } else {
                     MagiChemMod.LOGGER.warn("&&& Couldn't find item \""+key+"\" for sublimation recipe \""+pRecipeId);
                 }
@@ -297,15 +316,7 @@ public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             int wisdom = nbt.getInt("wisdom");
 
             //alchemy object
-            ResourceLocation alchemyObjectRL = new ResourceLocation(nbtAlchemyObject.getString("item"));
-            Item alchemyObjectItem = ForgeRegistries.ITEMS.getValue(alchemyObjectRL);
-            ItemStack alchemyObject = ItemStack.EMPTY;
-            if(alchemyObjectItem != null) {
-                if(nbtAlchemyObject.contains("count"))
-                    alchemyObject = new ItemStack(alchemyObjectItem, nbtAlchemyObject.getInt("count"));
-                else
-                    alchemyObject = new ItemStack(alchemyObjectItem, 1);
-            }
+            ItemStack alchemyObject = ItemStack.of(nbtAlchemyObject);
 
             int stagesCount = nbtStages.getInt("count");
             NonNullList<InfusionStage> infusionStages = NonNullList.create();
@@ -374,10 +385,7 @@ public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             nbt.putInt("tier", recipe.getTier());
             nbt.putInt("wisdom", recipe.getWisdom());
 
-            CompoundTag nbtAlchemyObject = new CompoundTag();
-            nbtAlchemyObject.putString("item", ForgeRegistries.ITEMS.getKey(recipe.getAlchemyObject().getItem()).toString());
-            nbtAlchemyObject.putInt("count", recipe.getAlchemyObject().getCount());
-            nbt.put("alchemyObject", nbtAlchemyObject);
+            nbt.put("alchemyObject", recipe.getAlchemyObject().serializeNBT());
 
             CompoundTag nbtStages = new CompoundTag();
             nbtStages.putInt("count", recipe.getStages(false).size());

--- a/src/main/java/com/aranaira/magichem/recipe/SublimationRecipe.java
+++ b/src/main/java/com/aranaira/magichem/recipe/SublimationRecipe.java
@@ -32,10 +32,12 @@ import java.util.List;
 /**
  * This recipe type is used by the Ritual of the Balanced Scales.
  */
-public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
+public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe, NbtPreservingRecipe {
     private final ResourceLocation id;
     private final int tier, wisdom;
     private final ItemStack alchemyObject;
+    @Nullable
+    private final Item nbtSource;
     private final NonNullList<InfusionStage> stages;
     private static final NonNullList<ItemStack> allPossibleOutputs = NonNullList.create();
     private final ResourceLocation requiredAdvancement, forbiddenAdvancement, grantedAdvancement;
@@ -43,6 +45,14 @@ public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
     public SublimationRecipe(ResourceLocation pID, int pTier, int pWisdom, ItemStack pAlchemyObject,
                              NonNullList<InfusionStage> pStages,
                              ResourceLocation pRequiredAdvancement, ResourceLocation pForbiddenAdvancement, ResourceLocation pGrantedAdvancement) {
+        this(pID, pTier, pWisdom, pAlchemyObject, pStages, pRequiredAdvancement,
+                pForbiddenAdvancement, pGrantedAdvancement, null);
+    }
+
+    public SublimationRecipe(ResourceLocation pID, int pTier, int pWisdom, ItemStack pAlchemyObject,
+                             NonNullList<InfusionStage> pStages,
+                             ResourceLocation pRequiredAdvancement, ResourceLocation pForbiddenAdvancement,
+                             ResourceLocation pGrantedAdvancement, @Nullable Item pNbtSource) {
         this.id = pID;
         this.stages = pStages;
         this.tier = pTier;
@@ -51,6 +61,7 @@ public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
         this.requiredAdvancement = pRequiredAdvancement;
         this.forbiddenAdvancement = pForbiddenAdvancement;
         this.grantedAdvancement = pGrantedAdvancement;
+        this.nbtSource = pNbtSource;
     }
 
     /**
@@ -107,6 +118,11 @@ public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
 
     public ItemStack getAlchemyObject() {
         return alchemyObject;
+    }
+
+    @Override
+    public @Nullable Item getNbtSource() {
+        return nbtSource;
     }
 
     public boolean isAdvancementRequired() {
@@ -303,7 +319,22 @@ public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             if(pSerializedRecipe.has("granted_advancement"))
                 grantedAdvancementRL = new ResourceLocation(GsonHelper.getAsString(pSerializedRecipe, "granted_advancement"));
 
-            return new SublimationRecipe(pRecipeId, tier, wisdom, recipeStack, extractedStages, requiredAdvancementRL, forbiddenAdvancementRL, grantedAdvancementRL);
+            Item nbtSource = RecipeNbtHelper.readOptionalSource(pSerializedRecipe, pRecipeId);
+            if(nbtSource != null) {
+                int occurrences = extractedStages.stream()
+                        .flatMap(stage -> stage.componentItems.stream())
+                        .mapToInt(stack -> stack.getItem() == nbtSource ? stack.getCount() : 0)
+                        .sum();
+                if(occurrences != 1)
+                    throw RecipeNbtHelper.error(pRecipeId,
+                            "preserve_nbt.item must occur exactly once among all stage components");
+                if(recipeStack.getCount() != 1)
+                    throw RecipeNbtHelper.error(pRecipeId,
+                            "the output count must be exactly one when preserve_nbt is used");
+            }
+
+            return new SublimationRecipe(pRecipeId, tier, wisdom, recipeStack, extractedStages,
+                    requiredAdvancementRL, forbiddenAdvancementRL, grantedAdvancementRL, nbtSource);
         }
 
         @Override
@@ -375,7 +406,9 @@ public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             if(nbt.contains("granted_advancement"))
                 grantedAdvancementRL = new ResourceLocation(nbt.getString("granted_advancement"));
 
-            return new SublimationRecipe(id, tier, wisdom, alchemyObject, infusionStages, requiredAdvancementRL, forbiddenAdvancementRL, grantedAdvancementRL);
+            Item nbtSource = RecipeNbtHelper.readNetworkSource(nbt);
+            return new SublimationRecipe(id, tier, wisdom, alchemyObject, infusionStages,
+                    requiredAdvancementRL, forbiddenAdvancementRL, grantedAdvancementRL, nbtSource);
         }
 
         @Override
@@ -384,6 +417,7 @@ public class SublimationRecipe implements Recipe<SimpleContainer>, IMARecipe {
 
             nbt.putInt("tier", recipe.getTier());
             nbt.putInt("wisdom", recipe.getWisdom());
+            RecipeNbtHelper.writeNetworkSource(nbt, recipe);
 
             nbt.put("alchemyObject", recipe.getAlchemyObject().serializeNBT());
 

--- a/src/main/java/com/aranaira/magichem/recipe/VitriolationRecipe.java
+++ b/src/main/java/com/aranaira/magichem/recipe/VitriolationRecipe.java
@@ -33,16 +33,23 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
-public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe {
+public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe, NbtPreservingRecipe {
     private final ResourceLocation id;
     private final ItemStack inputItem, resultItem, outputForCodex;
     private final FluidStack resultFluid;
     private final Fluid inputFluidOverride;
+    @Nullable
+    private final Item nbtSource;
     private final int craftTicks, minimumAcidStrength, mBConsumed;
     private static final HashMap<Integer, ArrayList<FluidType>> allAcids = new HashMap();
     private static final HashMap<Integer, ArrayList<Fluid>> allAcidsAsFluids = new HashMap();
 
     public VitriolationRecipe(ResourceLocation pID, ItemStack pInputItem, ItemStack pResultItem, FluidStack pResultFluid, int pCraftTicks, int pMinimumAcidStrength, int pMBConsumed, Fluid pInputFluidOverride, ItemStack pOutputForCodex) {
+        this(pID, pInputItem, pResultItem, pResultFluid, pCraftTicks, pMinimumAcidStrength,
+                pMBConsumed, pInputFluidOverride, pOutputForCodex, null);
+    }
+
+    public VitriolationRecipe(ResourceLocation pID, ItemStack pInputItem, ItemStack pResultItem, FluidStack pResultFluid, int pCraftTicks, int pMinimumAcidStrength, int pMBConsumed, Fluid pInputFluidOverride, ItemStack pOutputForCodex, @Nullable Item pNbtSource) {
         this.id = pID;
         this.inputItem = pInputItem;
         this.resultItem = pResultItem;
@@ -52,6 +59,7 @@ public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe {
         this.mBConsumed = pMBConsumed;
         this.inputFluidOverride = pInputFluidOverride;
         this.outputForCodex = pOutputForCodex;
+        this.nbtSource = pNbtSource;
 
         ArrayList<FluidType>[] acidLists = new ArrayList[]{
                 new ArrayList<FluidType>(),
@@ -88,6 +96,11 @@ public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe {
 
     public ItemStack getInputItem() {
         return inputItem;
+    }
+
+    @Override
+    public @Nullable Item getNbtSource() {
+        return nbtSource;
     }
 
     @Override
@@ -357,13 +370,25 @@ public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe {
                     ? ItemStack.EMPTY
                     : RecipeOutputHelper.applyNbt(new ItemStack(resultItemAsItem, resultItemCount), resultItemObject, pRecipeId);
 
+            Item nbtSource = null;
+            if(RecipeNbtHelper.readOptionalBoolean(pSerializedRecipe, pRecipeId)) {
+                if(resultItem.isEmpty())
+                    throw RecipeNbtHelper.error(pRecipeId,
+                            "preserve_nbt requires an item output, not a fluid-only output");
+                if(inputItemCount != 1 || resultItem.getCount() != 1)
+                    throw RecipeNbtHelper.error(pRecipeId,
+                            "vitriolation input and output counts must both be exactly one");
+                nbtSource = inputItemAsItem;
+            }
+
             return new VitriolationRecipe(pRecipeId,
                     new ItemStack(inputItemAsItem, inputItemCount),
                     resultItem,
                     resultFluidAsFluid == null ? FluidStack.EMPTY : new FluidStack(resultFluidAsFluid, resultFluidCount),
                     craftTicks, minimumAcidStrength, mBConsumed,
                     inputFluidOverrideAsFluid,
-                    new ItemStack((outputForCodexAsItem == null || outputForCodexAsItem == Items.AIR) ? ItemRegistry.PROBLEMITE.get() : outputForCodexAsItem)
+                    new ItemStack((outputForCodexAsItem == null || outputForCodexAsItem == Items.AIR) ? ItemRegistry.PROBLEMITE.get() : outputForCodexAsItem),
+                    nbtSource
             );
         }
 
@@ -404,6 +429,7 @@ public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             }
 
             ItemStack resultItem = !hasResultItem ? ItemStack.EMPTY : ItemStack.of(nbt.getCompound("resultItem"));
+            Item nbtSource = RecipeNbtHelper.readNetworkSource(nbt);
 
             return new VitriolationRecipe(pRecipeId,
                     inputAsItem == null ? ItemStack.EMPTY : new ItemStack(inputAsItem, inputCount),
@@ -411,7 +437,8 @@ public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe {
                     !hasResultFluid ? FluidStack.EMPTY : new FluidStack(resultFluidAsFluid, resultFluidCount),
                     craftTicks, minimumAcidStrength, mBConsumed,
                     inputFluidOverrideAsFluid,
-                    !hasOutputForCodex ? ItemStack.EMPTY : new ItemStack(outputForCodexAsItem)
+                    !hasOutputForCodex ? ItemStack.EMPTY : new ItemStack(outputForCodexAsItem),
+                    nbtSource
             );
         }
 
@@ -446,6 +473,7 @@ public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             if(pRecipe.outputForCodex != null && !pRecipe.outputForCodex.isEmpty()) {
                 nbt.putString("outputForCodex", ForgeRegistries.ITEMS.getKey(pRecipe.outputForCodex.getItem()).toString());
             }
+            RecipeNbtHelper.writeNetworkSource(nbt, pRecipe);
 
             pBuffer.writeNbt(nbt);
         }

--- a/src/main/java/com/aranaira/magichem/recipe/VitriolationRecipe.java
+++ b/src/main/java/com/aranaira/magichem/recipe/VitriolationRecipe.java
@@ -353,9 +353,13 @@ public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe {
                 }
             }
 
+            ItemStack resultItem = resultItemAsItem == null
+                    ? ItemStack.EMPTY
+                    : RecipeOutputHelper.applyNbt(new ItemStack(resultItemAsItem, resultItemCount), resultItemObject, pRecipeId);
+
             return new VitriolationRecipe(pRecipeId,
                     new ItemStack(inputItemAsItem, inputItemCount),
-                    resultItemAsItem == null ? ItemStack.EMPTY : new ItemStack(resultItemAsItem, resultItemCount),
+                    resultItem,
                     resultFluidAsFluid == null ? FluidStack.EMPTY : new FluidStack(resultFluidAsFluid, resultFluidCount),
                     craftTicks, minimumAcidStrength, mBConsumed,
                     inputFluidOverrideAsFluid,
@@ -376,13 +380,6 @@ public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             int inputCount = inputItemTag.getInt("count");
 
             boolean hasResultItem = nbt.contains("resultItem");
-            Item resultItemAsItem = null;
-            int resultItemCount = 0;
-            if(hasResultItem) {
-                CompoundTag resultItemTag = nbt.getCompound("resultItem");
-                resultItemAsItem = ForgeRegistries.ITEMS.getValue(new ResourceLocation(resultItemTag.getString("item")));
-                resultItemCount = resultItemTag.getInt("count");
-            }
 
             boolean hasResultFluid = nbt.contains("resultFluid");
             Fluid resultFluidAsFluid = null;
@@ -406,9 +403,11 @@ public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe {
                 outputForCodexAsItem = ForgeRegistries.ITEMS.getValue(new ResourceLocation(nbt.getString("outputForCodex")));
             }
 
+            ItemStack resultItem = !hasResultItem ? ItemStack.EMPTY : ItemStack.of(nbt.getCompound("resultItem"));
+
             return new VitriolationRecipe(pRecipeId,
                     inputAsItem == null ? ItemStack.EMPTY : new ItemStack(inputAsItem, inputCount),
-                    !hasResultItem ? ItemStack.EMPTY : new ItemStack(resultItemAsItem, resultItemCount),
+                    resultItem,
                     !hasResultFluid ? FluidStack.EMPTY : new FluidStack(resultFluidAsFluid, resultFluidCount),
                     craftTicks, minimumAcidStrength, mBConsumed,
                     inputFluidOverrideAsFluid,
@@ -426,10 +425,7 @@ public class VitriolationRecipe implements Recipe<SimpleContainer>, IMARecipe {
             nbt.put("inputItem", inputItemTag);
 
             if(pRecipe.hasResultItem()) {
-                CompoundTag resultItemTag = new CompoundTag();
-                resultItemTag.putString("item", ForgeRegistries.ITEMS.getKey(pRecipe.resultItem.getItem()).toString());
-                resultItemTag.putInt("count", pRecipe.resultItem.getCount());
-                nbt.put("resultItem", resultItemTag);
+                nbt.put("resultItem", pRecipe.resultItem.serializeNBT());
             }
 
             if(pRecipe.hasResultFluid()) {


### PR DESCRIPTION
## Recipe-authored output NBT
Sublimation and exaltation recipes can now attach SNBT data directly to their output item.
Sublimation recipes specify it in the `object`, for example:
```json
"object": {
  "item": "irons_spellbooks:scroll",
  "nbt": "{'irons_spellbooks:spell_container':{data:[{id:'irons_spellbooks:charge',index:0,level:1}],maxSpells:1,mustEquip:0b,spellWheel:0b}}"
}
```
Exaltation recipes specify it in the `result`, for example:
```json
"result": {
  "item": "irons_restrictions:manuscript",
  "count": 1,
  "nbt": "{SchoolId:\"irons_spellbooks:ice\"}"
}
```
The `nbt` value is parsed as SNBT when recipes load. Invalid SNBT produces a recipe-specific `JsonSyntaxException` rather than silently creating an incorrect result.

Recipe output stacks are serialized in full when synchronized to clients, preserving their tags. Sublimation and exaltation recipe selection is also tag-aware, allowing recipes with the same output item but different output NBT to remain distinguishable. Selected recipes are persisted by recipe ID, and device selection packets carry the complete output stack rather than only its registered item.

Existing recipes without `nbt` are unchanged.

## Input NBT preservation
Exaltation, illumination, and vitriolation recipes can opt into preserving the NBT of their single item input:
```json
"preserve_nbt": true
```
The preservation source is inferred from the recipe:
- Exaltation: `items.type`
- Illumination: `input`
- Vitriolation: `inputItem.item`

Because sublimation recipes may consume several different items across multiple stages, they instead identify the source item explicitly:
```json
"preserve_nbt": {
  "item": "example:upgradable_item"
}
```
That item must occur exactly once, with a count of one, among all sublimation stage components. This lets the Alchemical Nexus capture the correct stack even when the source is consumed before the final stage completes.

Preservation is recipe-scoped and disabled when preserve_nbt is absent or false. For enabled recipes, both the selected input and output must have a count of one; vitriolation additionally requires an item output.

When crafting completes, the device:
1. Copies the selected input stack’s NBT.
2. Merges the recipe-authored output NBT over it, so explicitly authored output fields take precedence.
3. Removes device-only transient data such as the Astral Observer’s `magichemLumins` field.
4. Applies the merged tag to the recipe output.

The preservation source is included in recipe network serialization. The Prime Aggregator and Alchemical Nexus also persist the consumed source stack through block saves, update tags, and in-progress crafting data, so preservation survives world reloads after input consumption. Output capacity checks compare complete tagged stacks, preventing incompatible tagged outputs from being merged.

The implementation is shared through `NbtPreservingRecipe` and `RecipeNbtHelper`, while each device handles input capture at the point appropriate to its crafting lifecycle. Both recipe-authored outputs and NBT preservation were verified in game across the four supported processes.